### PR TITLE
Items - index and show endpoints

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -1,0 +1,13 @@
+class Api::V1::ItemsController < ApplicationController
+  def index
+    per_page = find_per_page
+    page = find_page
+    items = Item.all.offset(page * per_page).limit(per_page)
+    render json: ItemSerializer.format_items(items)
+  end
+
+  def show
+    item = Item.find(params[:id])
+    render json: ItemSerializer.format_item(item)
+  end
+end

--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -10,22 +10,4 @@ class Api::V1::MerchantsController < ApplicationController
     merchant = Merchant.find(params[:id])
     render json: MerchantSerializer.format_merchant(merchant)
   end
-
-  private
-
-  def find_page
-    if params[:page].to_i == 0
-      params[:page].to_i
-    else
-      params[:page].to_i - 1
-    end
-  end
-
-  def find_per_page
-    if params[:per_page].present?
-      params[:per_page].to_i
-    else
-      20
-    end
-  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,9 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+
+  private
+
+  def record_not_found
+    render plain: "404 Not Found", status: 404
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,4 +6,20 @@ class ApplicationController < ActionController::API
   def record_not_found
     render plain: "404 Not Found", status: 404
   end
+
+  def find_page
+    if params[:page].to_i == 0
+      params[:page].to_i
+    else
+      params[:page].to_i - 1
+    end
+  end
+
+  def find_per_page
+    if params[:per_page].present?
+      params[:per_page].to_i
+    else
+      20
+    end
+  end
 end

--- a/app/serializers/item_serializer.rb
+++ b/app/serializers/item_serializer.rb
@@ -15,4 +15,18 @@ class ItemSerializer
       end
     }
   end
+
+  def self.format_item(item)
+    {data: {
+      id: item.id.to_s,
+      type: 'item',
+      attributes: {
+        name: item.name,
+        description: item.description,
+        unit_price: item.unit_price,
+        merchant_id: item.merchant_id
+      }
+    }
+    }
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,7 @@ Rails.application.routes.draw do
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
       end
+      resources :items, only: [:index, :show]
     end
   end
 end

--- a/spec/requests/api/v1/merchants/items_request_spec.rb
+++ b/spec/requests/api/v1/merchants/items_request_spec.rb
@@ -57,9 +57,9 @@ RSpec.describe 'Merchant Items API' do
       expect(items[:data].count).to eq(0)
     end
 
-    # it 'returns 404 when merchant not found' do
-    #   get "/api/v1/merchants/999999/items"
-    #   expect(response.status).to eq(404)
-    # end
+    it 'returns 404 when merchant not found' do
+      get "/api/v1/merchants/999999/items"
+      expect(response.status).to eq(404)
+    end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe 'Merchants API' do
     end
 
     it 'allows user to specify per page' do
-      create_list(:merchant, 50)
+      create_list(:merchant, 55)
 
       get '/api/v1/merchants?per_page=50'
 
@@ -75,8 +75,8 @@ RSpec.describe 'Merchants API' do
 
   describe '/merchants/:id' do
     it 'retrieves single merchant record' do
-      merchant = create(:merchant)
-      get "/api/v1/merchants/#{merchant.id}"
+      merchant_1 = create(:merchant)
+      get "/api/v1/merchants/#{merchant_1.id}"
 
       expect(response).to be_successful
 
@@ -102,7 +102,6 @@ RSpec.describe 'Merchants API' do
 
     it 'returns a 400 error when no merchant found' do
       get '/api/v1/merchants/999999'
-      # binding.pry
       expect(response.status).to eq(404)
     end
   end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -99,11 +99,11 @@ RSpec.describe 'Merchants API' do
       expect(merchant_data[:attributes]).to have_key(:name)
       expect(merchant_data[:attributes][:name]).to be_a(String)
     end
-    # 
-    # it 'returns a 400 error when no merchant found' do
-    #   get '/api/v1/merchants/999999'
-    #   # binding.pry
-    #   expect(response.status[:code]).to eq(404)
-    # end
+
+    it 'returns a 400 error when no merchant found' do
+      get '/api/v1/merchants/999999'
+      # binding.pry
+      expect(response.status).to eq(404)
+    end
   end
 end


### PR DESCRIPTION
Add '/items' endpoint
- default per page to 20; allow user input
- page defaults to page 1

Add '/items/:id' endpoint
- returns 404 with rescue from method when item not found 

* both endpoint returns formatted with serializer