### PR TITLE
Items - update endpoint

### DIFF
--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -18,7 +18,13 @@ class Api::V1::ItemsController < ApplicationController
 
   def destroy
     item = Item.find(params[:id])
-    item.delete
+    item.destroy
+  end
+
+  def update
+    item = Item.find(params[:id])
+    item.update!(item_params)
+    render json: ItemSerializer.format_item(item)
   end
 
   private

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -10,4 +10,20 @@ class Api::V1::ItemsController < ApplicationController
     item = Item.find(params[:id])
     render json: ItemSerializer.format_item(item)
   end
+
+  def create
+    item = Item.create!(item_params)
+    render json: ItemSerializer.format_item(item)
+  end
+
+  def destroy
+    item = Item.find(params[:id])
+    item.delete
+  end
+
+  private
+
+  def item_params
+    params.require(:item).permit(:name, :description, :unit_price, :merchant_id)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,20 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
+  rescue_from ActiveRecord::RecordInvalid, with: :bad_request
+  after_action :set_code_on_create, only: [:create]
 
   private
 
   def record_not_found
     render plain: "404 Not Found", status: 404
+  end
+
+  def bad_request
+    render plain: "400 Bad Request", status: 400
+  end
+
+  def set_code_on_create
+    response.status = 201 if response.status == 200
   end
 
   def find_page

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,7 @@
 class Item < ApplicationRecord
   belongs_to :merchant
-  has_many :invoice_items
+  has_many :invoice_items, dependent: :destroy
+  has_many :invoices, through: :invoice_items
 
   validates :name, presence: true
   validates :description, presence: true

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,4 +1,8 @@
 class Item < ApplicationRecord
   belongs_to :merchant
   has_many :invoice_items
+
+  validates :name, presence: true
+  validates :description, presence: true
+  validates :unit_price, numericality: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
       end
-      resources :items, only: [:index, :show, :create, :destroy]
+      resources :items
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
       end
-      resources :items, only: [:index, :show]
+      resources :items, only: [:index, :show, :create, :destroy]
     end
   end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -5,4 +5,10 @@ RSpec.describe Item, type: :model do
     it { should belong_to(:merchant) }
     it { should have_many(:invoice_items) }
   end
+
+  describe 'validations' do
+    it { should validate_presence_of(:name) }
+    it { should validate_presence_of(:description) }
+    it { should validate_numericality_of(:unit_price) }
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Item, type: :model do
   describe 'relationships' do
     it { should belong_to(:merchant) }
-    it { should have_many(:invoice_items) }
+    it { should have_many(:invoice_items).dependent(:destroy) }
+    it { should have_many(:invoices).through(:invoice_items) }
   end
 
   describe 'validations' do

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -114,5 +114,74 @@ RSpec.describe 'Items API' do
       get '/api/v1/items/999999'
       expect(response.status).to eq(404)
     end
+
+    it 'deletes an item by id' do
+      create_list(:item, 3)
+      item = create(:item)
+      expect(Item.all.count).to eq(4)
+      delete "/api/v1/items/#{item.id}"
+      expect(Item.all.count).to eq(3)
+
+      expect(response.status).to eq(204)
+    end
+
+    it 'sends 404 if item not found' do
+      create_list(:item, 3)
+      expect(Item.all.count).to eq(3)
+      
+      delete '/api/v1/items/99999'
+      expect(Item.all.count).to eq(3)
+
+      expect(response.status).to eq(404)
+    end
+  end
+
+  describe 'post to /api/v1/items' do
+    it 'can create a new item' do
+      merchant = create(:merchant)
+      item_params = {
+        "name": "cat socks",
+        "description": "tiny socks for cat feet",
+        "unit_price": 10.99,
+        "merchant_id": merchant.id
+        }
+      header = {"CONTENT_TYPE" => "application/json"}
+
+      post '/api/v1/items', headers: headers, params: {item: item_params}
+
+      expect(response).to be_successful
+      created_item = Item.last
+
+      expect(created_item.name).to eq(item_params[:name])
+      expect(created_item.description).to eq(item_params[:description])
+      expect(created_item.unit_price).to eq(item_params[:unit_price])
+      expect(created_item.merchant_id).to eq(merchant.id)
+    end
+
+    it 'will not create item without attributes' do
+      merchant = create(:merchant)
+      item_params = {name: "A thing",
+                     merchant_id: merchant.id
+                    }
+      header = {"CONTENT_TYPE" => "application/json"}
+
+      post '/api/v1/items', headers: headers, params: {item: item_params}
+
+      expect(response.status).to eq(400)
+    end
+
+    it 'will not create item with incorrect attribute data types' do
+      merchant = create(:merchant)
+      item_params = {name: 7545324,
+                     description: 87675,
+                     unit_price: "forty-five dollars",
+                     merchant_id: merchant.id
+                    }
+      header = {"CONTENT_TYPE" => "application/json"}
+
+      post '/api/v1/items', headers: headers, params: {item: item_params}
+
+      expect(response.status).to eq(400)
+    end
   end
 end


### PR DESCRIPTION
Add patch '/api/v1/items/:id' endpoint
- items can be updated with valid data types or merchant ids
- items will send 400 error for incorrect data types or merchant ids