### PR TITLE
Item merchant

### DIFF
--- a/app/controllers/api/v1/items/merchant_controller.rb
+++ b/app/controllers/api/v1/items/merchant_controller.rb
@@ -1,0 +1,6 @@
+class Api::V1::Items::MerchantController < ApplicationController
+  def show
+    merchant = Item.find(params[:item_id]).merchant
+    render json: MerchantSerializer.format_merchant(merchant)
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,9 @@ Rails.application.routes.draw do
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
       end
-      resources :items
+      resources :items do
+        get '/merchant', to: 'items/merchant#show'
+      end
     end
   end
 end

--- a/spec/requests/api/v1/items/merchants_request_spec.rb
+++ b/spec/requests/api/v1/items/merchants_request_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'Items Merchant API' do
+  describe '/api/vi/items/:id/merchant' do
+    it 'returns merchant info for given item' do
+      merchant_1 = create(:merchant)
+      merchant_2 = create(:merchant)
+
+      item_1 = create(:item, merchant: merchant_1)
+      item_2 = create(:item, merchant: merchant_2)
+
+      get "/api/v1/items/#{item_1.id}/merchant"
+
+      merchant = JSON.parse(response.body, symbolize_names: true)
+
+      expect(response).to be_successful
+      expect(merchant).to be_a(Hash)
+      expect(merchant).to have_key(:data)
+
+      expect(merchant[:data]).to have_key(:id)
+      expect(merchant[:data][:id]).to be_a(String)
+
+      expect(merchant[:data]).to have_key(:type)
+      expect(merchant[:data][:type]).to be_a(String)
+
+      expect(merchant[:data]).to have_key(:attributes)
+      expect(merchant[:data][:attributes]).to be_a(Hash)
+
+      merch_attr = merchant[:data][:attributes]
+      expect(merch_attr).to have_key(:name)
+      expect(merch_attr[:name]).to be_a(String)
+    end
+
+    it 'returns 404 for incorrect item ids' do
+      get "/api/v1/items/765875/merchant"
+
+      expect(response.status).to eq(404)
+
+      get "/api/v1/items/kjasdlhfg/merchant"
+
+      expect(response.status).to eq(404)
+    end
+  end
+end


### PR DESCRIPTION
Add get '/api/v1/items/:id/merchant' endpoint
- returns formatted merchant info for valid requests
- returns 404 for invalid requests