### PR TITLE
Find all items - name and unit_price search

### DIFF
--- a/app/controllers/api/v1/items/search_controller.rb
+++ b/app/controllers/api/v1/items/search_controller.rb
@@ -1,0 +1,39 @@
+class Api::V1::Items::SearchController < ApplicationController
+  def index
+    if params_present?
+      if mixed_params?
+        bad_request
+      else
+        items = item_search
+        render json: ItemSerializer.format_items(items)
+      end
+    else
+      bad_request
+    end
+  end
+
+  private
+
+  def params_present?
+    params[:name].present? ||
+    params[:min_price].present? ||
+    params[:max_price].present?
+  end
+
+  def mixed_params?
+    params[:name].present? && params[:min_price].present? ||
+    params[:name].present? && params[:max_price].present?
+  end
+
+  def item_search
+    if params[:name].present?
+      Item.search_by_name(params[:name])
+    elsif params[:max_price].present? && params[:min_price].present?
+      Item.in_price_range(params[:min_price], params[:max_price])
+    elsif params[:min_price].present?
+      Item.price_above(params[:min_price])
+    elsif params[:max_price].present?
+      Item.price_below(params[:max_price])
+    end
+  end
+end

--- a/app/controllers/api/v1/items_controller.rb
+++ b/app/controllers/api/v1/items_controller.rb
@@ -19,6 +19,7 @@ class Api::V1::ItemsController < ApplicationController
   def destroy
     item = Item.find(params[:id])
     item.destroy
+    Invoice.destroy_empty_invoices
   end
 
   def update

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::API
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
   rescue_from ActiveRecord::RecordInvalid, with: :bad_request
+  rescue_from ActiveRecord::StatementInvalid, with: :bad_request
   after_action :set_code_on_create, only: [:create]
 
   private
@@ -32,4 +33,5 @@ class ApplicationController < ActionController::API
       20
     end
   end
+
 end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,3 +1,8 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
+
+  def self.search_by_name(name)
+    where("name ILIKE ?", "%#{name}%")
+    .order(name: :asc)
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -3,4 +3,9 @@ class Invoice < ApplicationRecord
   belongs_to :customer
   has_many :transactions
   has_many :invoice_items
+
+  def self.destroy_empty_invoices
+    empty_invoices = left_outer_joins(:invoice_items).where(invoice_items: {id: nil})
+    empty_invoices.destroy_all
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -6,4 +6,19 @@ class Item < ApplicationRecord
   validates :name, presence: true
   validates :description, presence: true
   validates :unit_price, numericality: true
+
+  def self.price_below(max)
+    where('unit_price <= ?', max)
+    .order(unit_price: :asc)
+  end
+
+  def self.price_above(min)
+    where('unit_price >= ?', min)
+    .order(unit_price: :asc)
+  end
+
+  def self.in_price_range(min, max)
+    max_items = price_below(max)
+    max_items.price_above(min)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,9 @@ Rails.application.routes.draw do
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
       end
+
+      get '/items/find_all', to: 'items/search#index'
+
       resources :items do
         get '/merchant', to: 'items/merchant#show'
       end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -5,4 +5,24 @@ RSpec.describe Invoice, type: :model do
     it { should have_many(:invoice_items) }
     it { should have_many(:transactions) }
   end
+
+  describe 'class methods' do
+    it 'destroy invoices with no items' do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      invoice_1 = create(:invoice)
+      invoice_2 = create(:invoice)
+      invoice_item_1 = create(:invoice_item, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, invoice: invoice_2, item: item_1)
+      invoice_item_3 = create(:invoice_item, invoice: invoice_2, item: item_2)
+
+      expect(Invoice.all.count).to eq(2)
+      item_1.destroy
+      Invoice.destroy_empty_invoices
+      expect(Invoice.all.count).to eq(1)
+      item_2.destroy
+      Invoice.destroy_empty_invoices
+      expect(Invoice.all.count).to eq(0)
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -12,4 +12,32 @@ RSpec.describe Item, type: :model do
     it { should validate_presence_of(:description) }
     it { should validate_numericality_of(:unit_price) }
   end
+
+  describe 'class methods' do
+    before(:each) do
+      @item_1 = create(:item, name: "Strawberry bouquette", unit_price: 50.56)
+      @item_2 = create(:item, name: "Berrylicious Boba kit", unit_price: 5.56)
+      @item_3 = create(:item, name: "Jingle Berry", unit_price: 15.56)
+      @item_4 = create(:item, name: "no fruit at all", unit_price: 0.56)
+    end
+    it 'finds items by name ordered alphabetically' do
+      expect(Item.search_by_name('berry')).to eq([@item_2, @item_3, @item_1])
+    end
+
+    it 'finds items within a price range, inclusively' do
+      expect(Item.in_price_range(5, 50)).to eq([@item_2, @item_3])
+      expect(Item.in_price_range(5.56, 50.56)).to eq([@item_2, @item_3, @item_1])
+      expect(Item.in_price_range(60, 100)).to eq([])
+    end
+
+    it 'finds items cheaper than or equal to a given price, inclusive' do
+      expect(Item.price_below(15.56)).to eq([@item_4, @item_2, @item_3])
+      expect(Item.price_below(0.50)).to eq([])
+    end
+
+    it 'finds items more expensive than give price, inclusive' do
+      expect(Item.price_above(20)).to eq([@item_1])
+      expect(Item.price_above(15.56)).to eq([@item_3, @item_1])
+    end
+  end
 end

--- a/spec/requests/api/v1/items/search_request_spec.rb
+++ b/spec/requests/api/v1/items/search_request_spec.rb
@@ -1,0 +1,119 @@
+require 'rails_helper'
+
+RSpec.describe 'Items Search API' do
+  describe '/api/v1/items/find_all' do
+    before(:each) do
+      @item_1 = create(:item, name: "Strawberry bouquette", unit_price: 50.56)
+      @item_2 = create(:item, name: "Berrylicious Boba kit", unit_price: 5.56)
+      @item_3 = create(:item, name: "Jingle Berry", unit_price: 15.56)
+      @item_4 = create(:item, name: "no fruit at all", unit_price: 0.56)
+    end
+    context 'name search' do
+      it 'finds all items for given name' do
+
+        get '/api/v1/items/find_all?name=berry'
+
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body, symbolize_names: true)
+        expect(items).to be_a(Hash)
+        expect(items).to have_key(:data)
+        expect(items[:data]).to be_an(Array)
+        expect(items[:data].count).to eq(3)
+        expect(items[:data][0]).to be_a(Hash)
+
+        items[:data].each do |item|
+          expect(item).to have_key(:id)
+          expect(item[:id]).to be_an(String)
+
+          expect(item).to have_key(:attributes)
+          expect(item[:attributes]).to be_a(Hash)
+
+          expect(item[:attributes]).to have_key(:name)
+          expect(item[:attributes][:name]).to be_a(String)
+
+          expect(item[:attributes]).to have_key(:description)
+          expect(item[:attributes][:description]).to be_a(String)
+
+          expect(item[:attributes]).to have_key(:unit_price)
+          expect(item[:attributes][:unit_price]).to be_a(Float)
+
+          expect(item[:attributes]).to have_key(:merchant_id)
+          expect(item[:attributes][:merchant_id]).to be_a(Integer)
+        end
+      end
+
+      it 'returns empty array for no items found' do
+        get '/api/v1/items/find_all?name=bloop'
+
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body, symbolize_names: true)
+        expect(items).to be_a(Hash)
+        expect(items).to have_key(:data)
+        expect(items[:data]).to be_an(Array)
+        expect(items[:data].count).to eq(0)
+      end
+    end
+
+    context 'price search' do
+      it 'returns items within a price range' do
+        get '/api/v1/items/find_all?max_price=50&min_price=5'
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body, symbolize_names: true)
+        expect(items).to be_a(Hash)
+        expect(items).to have_key(:data)
+        expect(items[:data]).to be_an(Array)
+        expect(items[:data].count).to eq(2)
+      end
+
+      it 'returns items priced above a min' do
+        get '/api/v1/items/find_all?max_price=20'
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body, symbolize_names: true)
+        expect(items).to be_a(Hash)
+        expect(items).to have_key(:data)
+        expect(items[:data]).to be_an(Array)
+        expect(items[:data].count).to eq(3)
+      end
+
+      it 'returns items priced below a max' do
+        get '/api/v1/items/find_all?min_price=20'
+        expect(response).to be_successful
+
+        items = JSON.parse(response.body, symbolize_names: true)
+        expect(items).to be_a(Hash)
+        expect(items).to have_key(:data)
+        expect(items[:data]).to be_an(Array)
+        expect(items[:data].count).to eq(1)
+      end
+
+      it 'returns an error without params' do
+        get '/api/v1/items/find_all'
+
+        expect(response.status).to eq(400)
+      end
+
+      it 'only accepts name or price params, not both' do
+        get '/api/v1/items/find_all?name=berry&min_price=20'
+        expect(response.status).to eq(400)
+
+        get '/api/v1/items/find_all?name=berry&max_price=20'
+        expect(response.status).to eq(400)
+      end
+
+      it 'does not accept strings for price params' do
+        get '/api/v1/items/find_all?min_price=hjh'
+        expect(response.status).to eq(400)
+
+        get '/api/v1/items/find_all?max_price=dfkjh'
+        expect(response.status).to eq(400)
+
+        get '/api/v1/items/find_all?max_price=dfkjh&min_price=34'
+        expect(response.status).to eq(400)
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/items_request_spec.rb
+++ b/spec/requests/api/v1/items_request_spec.rb
@@ -135,25 +135,25 @@ RSpec.describe 'Items API' do
       expect(response.status).to eq(404)
     end
 
-    # it 'deletes invoice if only item on invoice' do
-    #   item_1 = create(:item)
-    #   item_2 = create(:item)
-    #   invoice_1 = create(:invoice)
-    #   invoice_2 = create(:invoice)
-    #   invoice_item_1 = create(:invoice_item, invoice: invoice_1, item: item_1)
-    #   invoice_item_2 = create(:invoice_item, invoice: invoice_2, item: item_1)
-    #   invoice_item_3 = create(:invoice_item, invoice: invoice_2, item: item_2)
-    #
-    #   expect(Item.all.count).to eq(2)
-    #   expect(Invoice.all.count).to eq(2)
-    #   expect(InvoiceItem.all.count).to eq(3)
-    #
-    #   delete "/api/v1/items/#{item_1.id}"
-    #
-    #   expect(Item.all.count).to eq(1)
-    #   expect(Invoice.all.count).to eq(1)
-    #   expect(InvoiceItem.all.count).to eq(1)
-    # end
+    it 'deletes invoice if only item on invoice' do
+      item_1 = create(:item)
+      item_2 = create(:item)
+      invoice_1 = create(:invoice)
+      invoice_2 = create(:invoice)
+      invoice_item_1 = create(:invoice_item, invoice: invoice_1, item: item_1)
+      invoice_item_2 = create(:invoice_item, invoice: invoice_2, item: item_1)
+      invoice_item_3 = create(:invoice_item, invoice: invoice_2, item: item_2)
+
+      expect(Item.all.count).to eq(2)
+      expect(Invoice.all.count).to eq(2)
+      expect(InvoiceItem.all.count).to eq(3)
+
+      delete "/api/v1/items/#{item_1.id}"
+
+      expect(Item.all.count).to eq(1)
+      expect(Invoice.all.count).to eq(1)
+      expect(InvoiceItem.all.count).to eq(1)
+    end
   end
 
   describe 'post to /api/v1/items' do


### PR DESCRIPTION
Add  get '/api/v1/items/find_all' endpoint
- accepts name or unit_price parameters passed through query string
- returns 400 error with incomplete or incorrect params
  - does not accept name and unit_price params together
  - does not accept strings for unit_price params
 

**Unrelated addition - Add dependent destroy for empty invoices within item destroy action