### PR TITLE
Revenue

### DIFF
--- a/app/controllers/api/v1/merchants_controller.rb
+++ b/app/controllers/api/v1/merchants_controller.rb
@@ -10,4 +10,13 @@ class Api::V1::MerchantsController < ApplicationController
     merchant = Merchant.find(params[:id])
     render json: MerchantSerializer.format_merchant(merchant)
   end
+
+  def most_items
+    if valid_quantity?
+      merchants = Merchant.by_items_sold(params[:quantity].to_i)
+      render json: MerchantSerializer.format_merchants_items_sold(merchants)
+    else
+      bad_request
+    end
+  end
 end

--- a/app/controllers/api/v1/revenue/merchants_controller.rb
+++ b/app/controllers/api/v1/revenue/merchants_controller.rb
@@ -1,0 +1,15 @@
+class Api::V1::Revenue::MerchantsController < ApplicationController
+  def index
+    if valid_quantity?
+      merchants = Merchant.by_revenue(params[:quantity].to_i)
+      render json: MerchantSerializer.format_merchants_revenue(merchants)
+    else
+      bad_request
+    end
+  end
+
+  def show
+    merchant = Merchant.find(params[:id])
+    render json: MerchantSerializer.format_merchant_revenue(merchant)
+  end
+end

--- a/app/controllers/api/v1/revenue_controller.rb
+++ b/app/controllers/api/v1/revenue_controller.rb
@@ -1,0 +1,23 @@
+class Api::V1::RevenueController < ApplicationController
+  def show
+    if dates_present? && dates_valid? # params[:start_date].present? && params[:end_date].present?
+      revenue = Invoice.total_revenue_between(params[:start], params[:end])
+      render json: RevenueSerializer.format_date_range_revenue(revenue)
+    else
+      bad_request
+    end
+  end
+
+  private
+
+  def dates_present?
+    params[:start].present? && params[:end].present?
+  end
+
+  def dates_valid?
+    format = '%Y-%m-%d'
+    DateTime.strptime(params[:start], format)
+    DateTime.strptime(params[:end], format)
+    true
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,11 +7,11 @@ class ApplicationController < ActionController::API
   private
 
   def record_not_found
-    render plain: "404 Not Found", status: 404
+    render json: { error: "404 Not Found" }, status: 404
   end
 
   def bad_request
-    render plain: "400 Bad Request", status: 400
+    render json: { error: "400 Bad Request" }, status: 400
   end
 
   def set_code_on_create
@@ -34,4 +34,7 @@ class ApplicationController < ActionController::API
     end
   end
 
+  def valid_quantity?
+    params[:quantity].present? && params[:quantity].to_i != 0
+  end
 end

--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -9,10 +9,22 @@ class Invoice < ApplicationRecord
     empty_invoices.destroy_all
   end
 
+  def self.start_date_format(start)
+    DateTime.strptime(start, '%Y-%m-%d').beginning_of_day
+  end
+
+  def self.end_date_format(end_date)
+    DateTime.strptime(end_date, '%Y-%m-%d').end_of_day
+  end
+
   def self.total_revenue_between(start_date, end_date)
+    start = start_date_format(start_date)
+    end_of_date = end_date_format(end_date)
     joins(:invoice_items, :transactions)
     .where('transactions.result = ?', "success")
-    .where('invoices.created_at >= ? AND invoices.created_at <= ?', start_date, end_date)
+    .where('invoices.created_at >= ? AND invoices.created_at <= ?', start, end_of_date)
+    .where('invoices.status = ?', 'shipped')
     .sum('invoice_items.quantity * invoice_items.unit_price')
   end
+
 end

--- a/app/serializers/merchant_serializer.rb
+++ b/app/serializers/merchant_serializer.rb
@@ -25,4 +25,40 @@ class MerchantSerializer
     {  data: { }
     }
   end
+
+  def self.format_merchants_revenue(merchants)
+    {  data:
+      merchants.map do |merch|
+        {id: merch.id.to_s,
+        type: 'merchant_name_revenue',
+        attributes: {
+          name: merch.name,
+          revenue: merch.revenue
+          }}
+      end
+    }
+  end
+
+  def self.format_merchant_revenue(merchant)
+    {  data:
+        {id: merchant.id.to_s,
+        type: 'merchant_revenue',
+        attributes: {
+          revenue: merchant.total_revenue
+          }}
+    }
+  end
+
+  def self.format_merchants_items_sold(merchants)
+    {  data:
+      merchants.map do |merch|
+        {id: merch.id.to_s,
+        type: 'merchant_name_revenue',
+        attributes: {
+          name: merch.name,
+          count: merch.items_sold
+          }}
+      end
+    }
+  end
 end

--- a/app/serializers/revenue_serializer.rb
+++ b/app/serializers/revenue_serializer.rb
@@ -1,0 +1,13 @@
+class RevenueSerializer
+  def self.format_date_range_revenue(revenue)
+    {
+      data: {
+        id: nil,
+        type: 'revenue',
+        attributes: {
+          revenue: revenue
+        }
+      }
+    }
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get '/merchants/find', to: 'merchants/search#show'
+      get '/merchants/most_items', to: 'merchants#most_items'
 
       resources :merchants, only: [:show, :index] do
         get '/items', to: 'merchants/items#index'
@@ -12,6 +13,11 @@ Rails.application.routes.draw do
 
       resources :items do
         get '/merchant', to: 'items/merchant#show'
+      end
+
+      get '/revenue', to: 'revenue#show'
+      namespace :revenue do
+        resources :merchants, only: [:index, :show]
       end
     end
   end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -44,5 +44,18 @@ RSpec.describe Invoice, type: :model do
       expect(Invoice.total_revenue_between('2000-02-04', '2005-05-06')).to eq(70)
       expect(Invoice.total_revenue_between('2020-02-04', '2021-05-03')).to eq(0)
     end
+
+    it 'formats start date for beginning of day' do
+      invoice_1 = create(:invoice, created_at: '1999-05-22') # revenue 10
+      invoice_2 = create(:invoice, created_at: '2000-02-04') # revenue 30
+      invoice_3 = create(:invoice, created_at: '2002-04-15') # failed; revenue 4
+      invoice_4 = create(:invoice, created_at: '2005-03-24') # revenue 40
+
+      expect(Invoice.start_date_format('2000-02-04')).to eq('Fri, 04 Feb 2000 00:00:00 +0000')
+    end
+
+    it 'formats end date for end of day' do
+      expect(Invoice.end_date_format('2005-03-24')).to eq('Thu, 24 Mar 2005 23:59:59.999999999 +0000')
+    end
   end
 end

--- a/spec/requests/api/v1/merchants_request_spec.rb
+++ b/spec/requests/api/v1/merchants_request_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'Merchants API' do
       merch_data = merchants[:data]
       merch_data.each do |merch|
         expect(merch).to have_key(:id)
-        expect(merch[:id]).to be_an(Integer)
+        expect(merch[:id]).to be_an(String)
 
         expect(merch).to have_key(:attributes)
         expect(merch[:attributes]).to be_a(Hash)
@@ -103,6 +103,83 @@ RSpec.describe 'Merchants API' do
     it 'returns a 400 error when no merchant found' do
       get '/api/v1/merchants/999999'
       expect(response.status).to eq(404)
+    end
+  end
+
+  describe '/api/v1/merchants/most_items?quantity=x' do
+    before(:each) do
+      @merchant_1 = create(:merchant) # revenue: 60, items sold: 3
+      @merchant_2 = create(:merchant) # revenue: 30 w/ failure; 80 if all successful, items sold: 4
+      @merchant_3 = create(:merchant) # revenue: 40, items sold: 2
+      @merchant_4 = create(:merchant)
+      @merchant_5 = create(:merchant)
+      @merchant_6 = create(:merchant)
+      @merchant_7 = create(:merchant)
+
+      @item_1 = create(:item, merchant: @merchant_1)
+      @item_2 = create(:item, merchant: @merchant_2)
+      @item_3 = create(:item, merchant: @merchant_3)
+      @item_4 = create(:item, merchant: @merchant_4)
+      @item_5 = create(:item, merchant: @merchant_5)
+      @item_6 = create(:item, merchant: @merchant_6)
+      @item_7 = create(:item, merchant: @merchant_7)
+
+      @invoice_1 = create(:invoice) #successful
+      @invoice_2 = create(:invoice) #successful
+      @invoice_3 = create(:invoice) #successful
+
+      @transaction_1 = create(:transaction, invoice: @invoice_1) #success
+      @transaction_2 = create(:transaction, invoice: @invoice_2) #success
+      @transaction_3 = create(:transaction, invoice: @invoice_3) #success
+
+      @invoice_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1)
+      @invoice_item_2 = create(:invoice_item, invoice: @invoice_2, item: @item_2)
+      @invoice_item_3 = create(:invoice_item, invoice: @invoice_3, item: @item_3)
+      @invoice_item_4 = create(:invoice_item, invoice: @invoice_1, item: @item_4)
+      @invoice_item_5 = create(:invoice_item, invoice: @invoice_2, item: @item_5)
+      @invoice_item_6 = create(:invoice_item, invoice: @invoice_3, item: @item_6)
+
+      @invoice_item_7 = create(:invoice_item, invoice: @invoice_1, item: @item_7, quantity: 2, unit_price: 20)
+    end
+    
+    it 'returns a list of merchants of given length' do
+      get '/api/v1/merchants/most_items?quantity=6'
+
+      expect(response).to be_successful
+      merchants = JSON.parse(response.body, symbolize_names: true)
+
+      expect(merchants).to be_a(Hash)
+      expect(merchants).to have_key(:data)
+      expect(merchants[:data]).to be_an(Array)
+      expect(merchants[:data].count).to eq(6)
+
+      merch_data = merchants[:data]
+      merch_data.each do |merch|
+        expect(merch).to have_key(:id)
+        expect(merch[:id]).to be_a(String)
+
+        expect(merch).to have_key(:type)
+        expect(merch[:type]).to be_a(String)
+
+        expect(merch).to have_key(:attributes)
+        expect(merch[:attributes]).to be_a(Hash)
+
+        expect(merch[:attributes]).to have_key(:name)
+        expect(merch[:attributes][:name]).to be_a(String)
+
+        expect(merch[:attributes]).to have_key(:count)
+        expect(merch[:attributes][:count]).to be_a(Integer)
+      end
+    end
+
+    it 'returns error if quantity a string' do
+      get '/api/v1/merchants/most_items?quantity=hsakldfh'
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns error if no quantity given' do
+      get '/api/v1/merchants/most_items'
+      expect(response.status).to eq(400)
     end
   end
 end

--- a/spec/requests/api/v1/revenue/merchants_request_spec.rb
+++ b/spec/requests/api/v1/revenue/merchants_request_spec.rb
@@ -1,0 +1,106 @@
+require 'rails_helper'
+
+RSpec.describe 'Revenue Merchants API' do
+  before(:each) do
+    @merchant_1 = create(:merchant) # revenue: 60, items sold: 3
+    @merchant_2 = create(:merchant) # revenue: 30 w/ failure; 80 if all successful, items sold: 4
+    @merchant_3 = create(:merchant) # revenue: 40, items sold: 2
+    @merchant_4 = create(:merchant)
+    @merchant_5 = create(:merchant)
+    @merchant_6 = create(:merchant)
+    @merchant_7 = create(:merchant)
+
+    @item_1 = create(:item, merchant: @merchant_1)
+    @item_2 = create(:item, merchant: @merchant_2)
+    @item_3 = create(:item, merchant: @merchant_3)
+    @item_4 = create(:item, merchant: @merchant_4)
+    @item_5 = create(:item, merchant: @merchant_5)
+    @item_6 = create(:item, merchant: @merchant_6)
+    @item_7 = create(:item, merchant: @merchant_7)
+
+    @invoice_1 = create(:invoice) #successful
+    @invoice_2 = create(:invoice) #successful
+    @invoice_3 = create(:invoice) #successful
+
+    @transaction_1 = create(:transaction, invoice: @invoice_1) #success
+    @transaction_2 = create(:transaction, invoice: @invoice_2) #success
+    @transaction_3 = create(:transaction, invoice: @invoice_3) #success
+
+    @invoice_item_1 = create(:invoice_item, invoice: @invoice_1, item: @item_1)
+    @invoice_item_2 = create(:invoice_item, invoice: @invoice_2, item: @item_2)
+    @invoice_item_3 = create(:invoice_item, invoice: @invoice_3, item: @item_3)
+    @invoice_item_4 = create(:invoice_item, invoice: @invoice_1, item: @item_4)
+    @invoice_item_5 = create(:invoice_item, invoice: @invoice_2, item: @item_5)
+    @invoice_item_6 = create(:invoice_item, invoice: @invoice_3, item: @item_6)
+
+    @invoice_item_7 = create(:invoice_item, invoice: @invoice_1, item: @item_7, quantity: 2, unit_price: 20)
+  end
+  describe '/api/v1/revenue/merchants?quantity=x' do
+    it 'returns a list of merchants of given length' do
+      get '/api/v1/revenue/merchants?quantity=6'
+
+      expect(response).to be_successful
+      merchants = JSON.parse(response.body, symbolize_names: true)
+
+      expect(merchants).to be_a(Hash)
+      expect(merchants).to have_key(:data)
+      expect(merchants[:data]).to be_an(Array)
+      expect(merchants[:data].count).to eq(6)
+
+      merch_data = merchants[:data]
+      merch_data.each do |merch|
+        expect(merch).to have_key(:id)
+        expect(merch[:id]).to be_a(String)
+
+        expect(merch).to have_key(:type)
+        expect(merch[:type]).to be_a(String)
+
+        expect(merch).to have_key(:attributes)
+        expect(merch[:attributes]).to be_a(Hash)
+
+        expect(merch[:attributes]).to have_key(:revenue)
+        expect(merch[:attributes][:revenue]).to be_a(Float)
+      end
+    end
+
+    it 'returns error if quantity a string' do
+      get '/api/v1/revenue/merchants?quantity=hsakldfh'
+      expect(response.status).to eq(400)
+    end
+
+    it 'returns error if no quantity given' do
+      get '/api/v1/revenue/merchants'
+      expect(response.status).to eq(400)
+    end
+  end
+
+  describe '/revenue/merchants/:id' do
+    it 'retrieves single merchant record' do
+      get "/api/v1/revenue/merchants/#{@merchant_1.id}"
+
+      expect(response).to be_successful
+
+      merchant = JSON.parse(response.body, symbolize_names: true)
+
+      expect(merchant).to have_key(:data)
+      expect(merchant[:data]).to be_a(Hash)
+
+      merchant_data = merchant[:data]
+
+      expect(merchant_data).to have_key(:id)
+      expect(merchant_data[:id]).to be_a(String)
+
+      expect(merchant_data).to have_key(:type)
+      expect(merchant_data[:type]).to be_a(String)
+
+      expect(merchant_data).to have_key(:attributes)
+      expect(merchant_data[:attributes]).to be_a(Hash)
+    end
+
+    it 'returns a 400 error when no merchant found' do
+      get '/api/v1/revenue/merchants/999999'
+      expect(response.status).to eq(404)
+    end
+  end
+
+end

--- a/spec/requests/api/v1/revenue/merchants_request_spec.rb
+++ b/spec/requests/api/v1/revenue/merchants_request_spec.rb
@@ -102,5 +102,4 @@ RSpec.describe 'Revenue Merchants API' do
       expect(response.status).to eq(404)
     end
   end
-
 end

--- a/spec/requests/api/v1/revenue_request_spec.rb
+++ b/spec/requests/api/v1/revenue_request_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'Revenue API' do
+  before(:each) do
+    @invoice_1 = create(:invoice, created_at: '1999-05-22') # revenue 10
+    @invoice_2 = create(:invoice, created_at: '2000-02-04') # revenue 30
+    @invoice_3 = create(:invoice, created_at: '2002-04-15') # failed; revenue 4
+    @invoice_4 = create(:invoice, created_at: '2005-03-24') # revenue 40
+
+    @invoice_item_1 = create(:invoice_item, invoice: @invoice_1, quantity: 2, unit_price: 5)
+    @invoice_item_2 = create(:invoice_item, invoice: @invoice_2, quantity: 2, unit_price: 15)
+    @invoice_item_3 = create(:invoice_item, invoice: @invoice_3, quantity: 2, unit_price: 2)
+    @invoice_item_4 = create(:invoice_item, invoice: @invoice_4, quantity: 2, unit_price: 20)
+
+    @transaction_1 = create(:transaction, invoice: @invoice_1)
+    @transaction_2 = create(:transaction, invoice: @invoice_2)
+    @transaction_3 = create(:transaction, invoice: @invoice_3, result: 'failed')
+    @transaction_4 = create(:transaction, invoice: @invoice_4)
+  end
+
+  describe '/api/v1/revenue?start_date&end_date' do
+    it 'returns total revenue for given date range' do
+      get '/api/v1/revenue?start=2000-02-04&end=2005-04-25'
+
+      expect(response).to be_successful
+
+      total_revenue = JSON.parse(response.body, symbolize_names: true)
+
+      expect(total_revenue).to be_a(Hash)
+      expect(total_revenue).to have_key(:data)
+      expect(total_revenue[:data]).to be_a(Hash)
+
+      expect(total_revenue[:data]).to have_key(:id)
+      expect(total_revenue[:data][:id].nil?).to eq(true)
+
+      expect(total_revenue[:data]).to have_key(:attributes)
+      expect(total_revenue[:data][:attributes]).to be_a(Hash)
+      expect(total_revenue[:data][:attributes]).to have_key(:revenue)
+    end
+
+    it 'returns error for incomplete date range' do
+      get '/api/v1/revenue?start=2002-02-04'
+      expect(response.status).to eq(400)
+
+      get '/api/v1/revenue?end=2002-02-04'
+      expect(response.status).to eq(400)
+
+      get '/api/v1/revenue'
+      expect(response.status).to eq(400)
+    end
+  end
+end


### PR DESCRIPTION
Add revenue endpoints
- 'revenue/merchants/:merchant_id'
  - returns total revenue for a single merchant
- 'revenue/merchants?quantity=x'
  - returns a list of merchants and their total revenue with user defined quantity of items in list
- 'revenue?start=xxxx-xx-xx&end=xxxx-xx-xx'
  - returns revenue across entire system for user defined date range
Add 'merchants/most_items?quantity=x'
- returns list of merchants of a user defined length sorted by and including number of items sold